### PR TITLE
Minimum Donation Treatment Update

### DIFF
--- a/src/linear.ts
+++ b/src/linear.ts
@@ -85,11 +85,6 @@ export const aggregateContributions = (
     list: {},
   };
 
-  for (const contribution of contributions) {
-    if (contribution.amount < options.minimumAmount) {
-      continue;
-    }
-
     ag.list[contribution.recipient] ||= {
       totalReceived: 0n,
       contributions: {},


### PR DESCRIPTION
Requesting deletion of minamount logic to reflect that this now lives in the coefficient (0/1) process to silence donations beneath the $1 minimum.